### PR TITLE
fix: iPhone SE3 설정탭에서 탭바 내려가는 버그 수정

### DIFF
--- a/Siksha/ContentView.swift
+++ b/Siksha/ContentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 private extension ContentView {
     func tabBar(_ geometry: GeometryProxy) -> some View {
-        HStack {
+        HStack(spacing: 48) {
             Spacer()
             ForEach(self.tabItems) { item in
                 Button(action: {
@@ -20,19 +20,19 @@ private extension ContentView {
                         .resizable()
                         .frame(width: 36, height: 46)
                 }
-                .padding(.bottom, geometry.safeAreaInsets.bottom)
                 .transaction { transaction in
                     transaction.animation = nil
                     transaction.disablesAnimations = true
                 }
-                
-                Spacer()
             }
+            Spacer()
         }
-        .frame(width: geometry.size.width, height: 50 + geometry.safeAreaInsets.bottom)
-        .background(Color.backgroundSecondary.shadow(color:Color(red: 0, green: 0, blue: 0,opacity: 0.05), radius: 0, x: 0, y: -0.3))
-        .padding(.top, -8)
-        .padding(.bottom, -geometry.safeAreaInsets.bottom)
+        .padding(.top, 5)
+        .padding(.bottom, geometry.safeAreaInsets.bottom)
+        .background(
+            Color.backgroundSecondary
+                .shadow(color: .black.opacity(0.05), radius: 3, x: 0, y: -2)
+        )
     }
 }
 
@@ -44,39 +44,29 @@ struct ContentView: View {
     
     struct TabItem: Identifiable {
         var id: Int
-        
         var content: AnyView
         var buttonImage: [String]
     }
     
-    let tabItems =
-        [TabItem(id: 0, content: AnyView(MenuView(isFavoriteTab: true).id("favorite")), buttonImage: ["Favorite", "Favorite-disabled"]),
+    let tabItems = [
+        TabItem(id: 0, content: AnyView(MenuView(isFavoriteTab: true).id("favorite")), buttonImage: ["Favorite", "Favorite-disabled"]),
         TabItem(id: 1, content: AnyView(MenuView().id("main")), buttonImage: ["Main", "Main-disabled"]),
         TabItem(id: 2, content: AnyView(CommunityView(viewModel: CommunityViewModel(communityRepository: DomainManager.shared.domain.communityRepository))), buttonImage: ["Community", "Community-disabled"]),
         TabItem(id: 3, content: AnyView(RenewalSettingsView(viewModel: RenewalSettingsViewModel())), buttonImage: ["Settings", "Settings-disabled"])
-        ]
+    ]
     
-  
     var body: some View {
-            GeometryReader { geometry in
-                NavigationStack {
-                    VStack {
-                            
-                            tabItems[selectedTab].content
-                            
-                            Spacer()
-                            tabBar(geometry)
-                            
-                        
-                    }
-                      .ignoresSafeArea(.keyboard, edges: .bottom)
-                    
-                   
+        GeometryReader { geometry in
+            NavigationStack {
+                VStack(spacing: 0) {
+                    tabItems[selectedTab].content
+                    tabBar(geometry)
                 }
-                .navigationViewStyle(StackNavigationViewStyle())
+                .frame(width: geometry.size.width)
+                .ignoresSafeArea(.all, edges: .bottom)
             }
-        
-        
+            .navigationViewStyle(StackNavigationViewStyle())
+        }
     }
 }
 
@@ -87,6 +77,7 @@ struct ContentView_Previews: PreviewProvider {
         ContentView()
     }
 }
+
 extension View{
     @ViewBuilder
     func If<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {

--- a/Siksha/ContentView.swift
+++ b/Siksha/ContentView.swift
@@ -28,7 +28,7 @@ private extension ContentView {
             Spacer()
         }
         .padding(.top, 5)
-        .padding(.bottom, geometry.safeAreaInsets.bottom)
+        .padding(.bottom, geometry.safeAreaInsets.bottom == 0 ? geometry.safeAreaInsets.bottom + 13 : geometry.safeAreaInsets.bottom - 2)
         .background(
             Color.backgroundSecondary
                 .shadow(color: .black.opacity(0.05), radius: 3, x: 0, y: -2)


### PR DESCRIPTION
## 작업 요약
- 탭바의 safe area와 padding 관련 로직 수정

## 관련 이슈
<!---- 이슈 모두 해결인 경우에만 'closes' 키워드 사용 -->
- closes #52 

## 변경 항목 (모두 체크)
<!---- 변경한 항목 모두 체크, 내용 수정 X -->
- [ ] 기능 추가
- [ ] 기능 개선
- [x] 버그 수정
- [x] 디자인 변경
- [x] 코드에 영향 주지 않는 변경(들여쓰기, 공백, 변수명 변경 등)
- [ ] 리팩토링
- [ ] 파일명/폴더명 수정
- [ ] 파일/폴더 삭제
- [ ] 빌드 설정 수정
- [ ] 패키지 매니저 수정
- [ ] 문서 수정
- [ ] 테스팅 코드

## 변경 내용 상세
<!---- draft pr 이용 시 먼저 할 일 리스트 모두 작성한 뒤 완성시마다 체크박스 체크-->
- [x] 음수 패딩값이 아닌 ignoreSafeArea 사용하도록 수정
- [x] SE3에서 탭 아이콘 아래 패딩값 추가(디자인팀 컨펌 필요)

## 변경 후 스크린샷/녹화 (필요 시)
<!---- 없으면 삭제 -->
* iPhone SE 3

https://github.com/user-attachments/assets/293c6386-b4a1-4b69-9359-21e93641cddf

* iPhone 17 Pro

https://github.com/user-attachments/assets/3cdb2390-ab8f-405f-92bb-880fcac87a25


## 향후 개선 필요 사항
<!---- 없으면 삭제 -->
-

## 리뷰 시 참고할 사항 및 집중 리뷰 요청 부분
<!---- 없으면 삭제 -->
- 각자 테스트하는 기종 탭바 바텀패딩과 특히 설정탭에서 탭바 이상 없는지 확인 필요

## 개발자 체크리스트
<!---- 체크박스만 체크, 내용 수정 X -->
- [x] 팀 코딩 컨벤션에 맞게 작성(README 혹은 Notion 확인)
- [x] 변경 사항 테스팅 완료 (버그수정 혹은 기능추가/개선)
- [x] client id와 같은 노출되면 안 되는 정보는 노출 X (커밋기록에 나타나는 것도 X)

## 리뷰어 체크리스트
<!---- 내용 수정 X -->
- 기능 검증(테스트)
- 코드 가독성, 중복 여부
- 성능 저하 우려 부분 존재 여부
- 예외 처리 및 오류 대응 여부
- 코딩 컨벤션 부합 여부
