### PR TITLE
fix: download all existing review images & send (#58)

### DIFF
--- a/Siksha/Review/MealReviewViewModel.swift
+++ b/Siksha/Review/MealReviewViewModel.swift
@@ -194,11 +194,11 @@ class MealReviewViewModel: ObservableObject {
         }
         
         if !review.imageUrls.isEmpty {
-            downloadImages(from: review.imageUrls)
+            downloadExistingImages(from: review.imageUrls)
         }
     }
     
-    private func downloadImages(from urls: [String]) {
+    private func downloadExistingImages(from urls: [String]) {
         let publishers = urls.compactMap { urlString -> AnyPublisher<UIImage?, Never>? in
             guard let url = URL(string: urlString) else { return nil }
             
@@ -223,7 +223,8 @@ class MealReviewViewModel: ObservableObject {
             return
         }
         
-        let imagesData = selectedImages.isEmpty ? nil : selectedImages.compactMap { $0.jpegData(compressionQuality: 0.5) }
+        // 전체 이미지를 Data로 변환 (기존 + 새로운 이미지 모두)
+        let allImagesData = selectedImages.compactMap { $0.jpegData(compressionQuality: 0.5) }
         
         Networking.shared.editReview(
             reviewId: reviewId,
@@ -233,15 +234,11 @@ class MealReviewViewModel: ObservableObject {
             taste: selectedKeywords[.taste] ?? "",
             price: selectedKeywords[.price] ?? "",
             foodComposition: selectedKeywords[.composition] ?? "",
-            images: imagesData
+            images: allImagesData.isEmpty ? nil : allImagesData
         )
         .receive(on: RunLoop.main)
         .sink { [weak self] result in
             guard let self = self else { return }
-
-            if let data = result.data {
-                print("  - data: \(String(data: data, encoding: .utf8) ?? "nil")")
-            }
             
             guard let response = result.response else {
                 self.postReviewSucceeded = false


### PR DESCRIPTION
## 작업 요약
- 리뷰 사진 수정 시 덮어쓰기 되는 오류 해결
- 기존 사진 전부 다운받고 재업로드하는 방식으로 합의

## 관련 이슈
- ex. closes #58 

## 변경 항목 (모두 체크)
<!---- 변경한 항목 모두 체크, 내용 수정 X -->
- [ ] 기능 추가
- [ ] 기능 개선
- [x] 버그 수정
- [ ] 디자인 변경
- [ ] 코드에 영향 주지 않는 변경(들여쓰기, 공백, 변수명 변경 등)
- [ ] 리팩토링
- [ ] 파일명/폴더명 수정
- [ ] 파일/폴더 삭제
- [ ] 빌드 설정 수정
- [ ] 패키지 매니저 수정
- [ ] 문서 수정
- [ ] 테스팅 코드

## 변경 내용 상세
<!---- draft pr 이용 시 먼저 할 일 리스트 모두 작성한 뒤 완성시마다 체크박스 체크-->
- [ ] ex. 필터 UI 컴포넌트 추가
- [ ] ex. 바텀시트 뷰 추가

## 개발자 체크리스트
<!---- 체크박스만 체크, 내용 수정 X -->
- [x] 팀 코딩 컨벤션에 맞게 작성(README 혹은 Notion 확인)
- [x] 변경 사항 테스팅 완료 (버그수정 혹은 기능추가/개선)
- [x] client id와 같은 노출되면 안 되는 정보는 노출 X (커밋기록에 나타나는 것도 X)

## 리뷰어 체크리스트
<!---- 내용 수정 X -->
- 기능 검증(테스트)
- 코드 가독성, 중복 여부
- 성능 저하 우려 부분 존재 여부
- 예외 처리 및 오류 대응 여부
- 코딩 컨벤션 부합 여부
