### PR TITLE
chore: restore deleted ObjC linker flag for Firebase Analytics

### DIFF
--- a/Siksha.xcodeproj/project.pbxproj
+++ b/Siksha.xcodeproj/project.pbxproj
@@ -1348,7 +1348,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.4.4;
-				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.wafflestudio.siksha.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1385,7 +1388,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.4.4;
-				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.wafflestudio.siksha";


### PR DESCRIPTION
## 작업 요약
- ObjC linker flag 복구

## 관련 이슈
<!---- 이슈 모두 해결인 경우에만 'closes' 키워드 사용 -->
- closes #60 

## 변경 항목 (모두 체크)
<!---- 변경한 항목 모두 체크, 내용 수정 X -->
- [ ] 기능 추가
- [ ] 기능 개선
- [ ] 버그 수정
- [ ] 디자인 변경
- [ ] 코드에 영향 주지 않는 변경(들여쓰기, 공백, 변수명 변경 등)
- [ ] 리팩토링
- [ ] 파일명/폴더명 수정
- [ ] 파일/폴더 삭제
- [x] 빌드 설정 수정
- [ ] 패키지 매니저 수정
- [ ] 문서 수정
- [ ] 테스팅 코드


## 변경 후 스크린샷
<!---- 없으면 삭제 -->
dev에서 앱버전 정상 전송 확인
<img width="1522" height="818" alt="image" src="https://github.com/user-attachments/assets/fd971538-18c5-40be-874b-443ccf73688c" />
Realtime Analytics 에서 기기 인식되는 것 확인
<img width="1938" height="1060" alt="image" src="https://github.com/user-attachments/assets/529ef369-66e3-497d-b65c-d587457f5e16" />

## 향후 개선 필요 사항
<!---- 없으면 삭제 -->
- 배포 후 모니터링 필요
